### PR TITLE
Fix for ember-cli@2.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
     "ember-cli-deploy-plugin": "^0.2.6",
+    "glob": "^7.1.1",
     "keen.io": "^0.1.3"
   },
   "ember-addon": {


### PR DESCRIPTION
ember-cli 2.10 does not include `glob` as a dependency anymore (see https://github.com/ember-cli/ember-cli/compare/v2.9.1...v2.10.0#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L84) but the addon relies on this dependency. So the addon did not work anymore after upgrading to ember-cli 2.10. This PR adds `glob` as an explicit dependency in `package.json`.