### PR TITLE
Allow customization of sendDeployData

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,23 @@ ENV['asset-sizes'] = {
   KEEN_WRITE_KEY: <your-keen-write-key>
 };
 ```
+
+### Customize tracking
+
+By default, this will use the keen.io dependency, together with KEEN_PROJECT_ID & KEEN_WRITE_KEY, 
+to track the file sizes.
+
+However, if you require custom functionality, you can configure your own `sendDeployData` function:
+
+```js
+ENV['asset-sizes'] = {
+  sendDeployData(assets, options) {
+    // Manually do something with the assets
+    // 'assets' is an array of objects with 'name', 'size' and 'gzipSize'
+  }
+}
+```
+
 ## Deploy
 
 ```sh

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /* jshint node: true */
 'use strict';
 
-var RSVP = require ('rsvp');
+var RSVP = require('rsvp');
 var DeployPluginBase = require('ember-cli-deploy-plugin');
 var path = require('path');
 
@@ -23,7 +23,7 @@ var sendDeployData = function(assets, options, keen) {
     var keenPayload = JSON.stringify({ deploy: pushedAssets });
 
     keen.addEvents(keenPayload, function(err, res) {
-      if(err) {
+      if (err) {
         reject(err);
       } else {
         resolve(res);
@@ -69,8 +69,12 @@ module.exports = {
         });
         var makeAssetSizesObject = sizePrinter.makeAssetSizesObject();
 
+        // this.readConfig('sendDeployData') will automatically call the function
+        // Instead, we take it from the pluginConfig
+        var sendDeployDataFunction = this.pluginConfig.sendDeployData || sendDeployData;
+
         return makeAssetSizesObject.then(function(assets) {
-          return sendDeployData(assets, options, keen);
+          return sendDeployDataFunction(assets, options, keen);
         });
       }
     });

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var chai  = require('chai');
+var chai = require('chai');
 var chaiAsPromised = require("chai-as-promised");
 chai.use(chaiAsPromised);
 
@@ -22,7 +22,8 @@ describe('deploy-asset-sizes plugin', function() {
   beforeEach(function() {
     mockUi = {
       messages: [],
-      write: function() {},
+      write: function() {
+      },
       writeLine: function(message) {
         this.messages.push(message);
       }
@@ -145,14 +146,14 @@ describe('deploy-asset-sizes plugin', function() {
               deploy: [
                 {
                   name: 'frontend.js',
-                  size: 18,
-                  gzipSize: 38,
+                  size: 19,
+                  gzipSize: 39,
                   showGzipped: true
                 },
                 {
                   name: 'vendor.js',
-                  size: 18,
-                  gzipSize: 38,
+                  size: 19,
+                  gzipSize: 39,
                   showGzipped: true
                 }
               ]
@@ -190,6 +191,40 @@ describe('deploy-asset-sizes plugin', function() {
 
       plugin.beforeHook(context);
       return assert.isRejected(plugin.willUpload(context));
+    });
+
+    it('allows overwriting of sendDeployData function', function(done) {
+      context.config['asset-sizes'].sendDeployData = function(assets) {
+        assert.equal(
+          JSON.stringify(assets),
+          JSON.stringify(
+            [
+              {
+                name: 'C:/projects/ember-cli-deploy-asset-sizes/tests/fixtures/dist/frontend-f8762e8292688aff9187bf2f37595888.js',
+                size: 19,
+                gzipSize: 39,
+                showGzipped: true
+              },
+              {
+                name: 'C:/projects/ember-cli-deploy-asset-sizes/tests/fixtures/dist/vendor.js',
+                size: 19,
+                gzipSize: 39,
+                showGzipped: true
+              }
+            ]
+          )
+        );
+      };
+
+      var plugin = subject.createDeployPlugin({
+        name: 'asset-sizes'
+      });
+
+      plugin.beforeHook(context);
+      assert.isFulfilled(plugin.willUpload(context))
+        .then(function() {
+          done();
+        });
     });
   });
 });


### PR DESCRIPTION
This PR makes it possible to specify a custom `sendDeployData` method in the deploy config.
This can be used to do some custom tracking, e.g. if you don't want to track to keen.io but to another service.